### PR TITLE
feat: 回答結果画面UIを実装してUX向上

### DIFF
--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AnswerResult } from "@/components/features/AnswerResult";
+import { SessionComplete } from "@/components/features/SessionComplete";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -36,12 +38,23 @@ interface Session {
   currentQuestionIndex: number;
 }
 
+interface AnswerResultData {
+  isCorrect: boolean;
+  userAnswer: string;
+  correctAnswers: string[];
+  japaneseMeaning: string;
+}
+
 export default function LearnPage() {
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [answer, setAnswer] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showResult, setShowResult] = useState(false);
+  const [resultData, setResultData] = useState<AnswerResultData | null>(null);
+  const [showComplete, setShowComplete] = useState(false);
+  const [correctCount, setCorrectCount] = useState(0);
   const router = useRouter();
 
   useEffect(() => {
@@ -98,7 +111,7 @@ export default function LearnPage() {
 
   const showCurrentQuestion = (questions: Question[], index: number) => {
     if (index >= questions.length) {
-      alert("全ての問題が完了しました！");
+      setShowComplete(true);
       return;
     }
 
@@ -124,7 +137,7 @@ export default function LearnPage() {
 
     const nextIndex = session.currentQuestionIndex + 1;
     if (nextIndex >= session.questions.length) {
-      alert("全ての問題が完了しました！");
+      setShowComplete(true);
       return;
     }
 
@@ -167,15 +180,19 @@ export default function LearnPage() {
 
       const answerData = result.data;
 
-      // 結果を表示（今後結果画面に移行）
+      // 正解数をカウント
       if (answerData.isCorrect) {
-        alert(`正解！ 答え: ${answerData.correctAnswers.join(", ")}`);
-      } else {
-        alert(`不正解。正解: ${answerData.correctAnswers.join(", ")}`);
+        setCorrectCount((prev) => prev + 1);
       }
 
-      // 次の問題へ
-      moveToNextQuestion();
+      // 結果データを設定して結果画面を表示
+      setResultData({
+        isCorrect: answerData.isCorrect,
+        userAnswer: answer.trim(),
+        correctAnswers: answerData.correctAnswers,
+        japaneseMeaning: currentWord.japanese,
+      });
+      setShowResult(true);
     } catch (error) {
       console.error("回答送信エラー:", error);
       alert("回答の送信に失敗しました");
@@ -187,6 +204,22 @@ export default function LearnPage() {
   const handleSkip = async () => {
     if (!currentWord || isSubmitting) return;
     moveToNextQuestion();
+  };
+
+  const handleResultNext = () => {
+    setShowResult(false);
+    setResultData(null);
+    moveToNextQuestion();
+  };
+
+  const handleRestartSession = () => {
+    setShowComplete(false);
+    setCorrectCount(0);
+    initializeSession();
+  };
+
+  const handleGoHome = () => {
+    router.push("/");
   };
 
   if (isLoading) {
@@ -284,6 +317,30 @@ export default function LearnPage() {
           ホームに戻る
         </Button>
       </div>
+
+      {/* 回答結果モーダル */}
+      {showResult && resultData && (
+        <AnswerResult
+          isCorrect={resultData.isCorrect}
+          userAnswer={resultData.userAnswer}
+          correctAnswers={resultData.correctAnswers}
+          japaneseMeaning={resultData.japaneseMeaning}
+          onNext={handleResultNext}
+          isLastQuestion={
+            session ? session.currentQuestionIndex + 1 >= session.questions.length : false
+          }
+        />
+      )}
+
+      {/* セッション完了モーダル */}
+      {showComplete && session && (
+        <SessionComplete
+          totalQuestions={session.questions.length}
+          correctCount={correctCount}
+          onRestart={handleRestartSession}
+          onHome={handleGoHome}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/features/AnswerResult.tsx
+++ b/src/components/features/AnswerResult.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CheckCircle, XCircle } from "lucide-react";
+
+interface AnswerResultProps {
+  isCorrect: boolean;
+  userAnswer: string;
+  correctAnswers: string[];
+  japaneseMeaning: string;
+  onNext: () => void;
+  isLastQuestion?: boolean;
+}
+
+export function AnswerResult({
+  isCorrect,
+  userAnswer,
+  correctAnswers,
+  japaneseMeaning,
+  onNext,
+  isLastQuestion = false,
+}: AnswerResultProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-center flex items-center justify-center gap-2">
+            {isCorrect ? (
+              <>
+                <CheckCircle className="text-green-500" size={32} />
+                <span className="text-green-600">正解！</span>
+              </>
+            ) : (
+              <>
+                <XCircle className="text-red-500" size={32} />
+                <span className="text-red-600">不正解</span>
+              </>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-center">
+            <p className="text-lg font-medium text-gray-700 mb-2">{japaneseMeaning}</p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">あなたの回答</p>
+              <p className={`font-medium ${isCorrect ? "text-green-600" : "text-red-600"}`}>
+                {userAnswer}
+              </p>
+            </div>
+
+            {!isCorrect && (
+              <div className="bg-green-50 p-3 rounded-lg">
+                <p className="text-sm text-gray-600 mb-1">正解</p>
+                <p className="font-medium text-green-600">{correctAnswers.join(", ")}</p>
+              </div>
+            )}
+
+            {isCorrect && correctAnswers.length > 1 && (
+              <div className="bg-blue-50 p-3 rounded-lg">
+                <p className="text-sm text-gray-600 mb-1">他の正解</p>
+                <p className="font-medium text-blue-600">
+                  {correctAnswers
+                    .filter((answer) => answer.toLowerCase() !== userAnswer.toLowerCase())
+                    .join(", ")}
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div className="pt-4">
+            <Button onClick={onNext} className="w-full" size="lg">
+              {isLastQuestion ? "結果を見る" : "次の問題"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/features/SessionComplete.tsx
+++ b/src/components/features/SessionComplete.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Home, RotateCcw, Trophy } from "lucide-react";
+
+interface SessionCompleteProps {
+  totalQuestions: number;
+  correctCount?: number;
+  onRestart: () => void;
+  onHome: () => void;
+}
+
+export function SessionComplete({
+  totalQuestions,
+  correctCount = 0,
+  onRestart,
+  onHome,
+}: SessionCompleteProps) {
+  const accuracy = totalQuestions > 0 ? Math.round((correctCount / totalQuestions) * 100) : 0;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-center flex items-center justify-center gap-2">
+            <Trophy className="text-yellow-500" size={32} />
+            <span className="text-gray-800">学習完了！</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="text-center">
+            <p className="text-lg text-gray-600 mb-4">お疲れさまでした！</p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="bg-blue-50 p-4 rounded-lg text-center">
+              <p className="text-sm text-gray-600 mb-1">総問題数</p>
+              <p className="text-2xl font-bold text-blue-600">{totalQuestions}</p>
+            </div>
+
+            {correctCount > 0 && (
+              <>
+                <div className="bg-green-50 p-4 rounded-lg text-center">
+                  <p className="text-sm text-gray-600 mb-1">正解数</p>
+                  <p className="text-2xl font-bold text-green-600">{correctCount}</p>
+                </div>
+
+                <div className="bg-purple-50 p-4 rounded-lg text-center">
+                  <p className="text-sm text-gray-600 mb-1">正解率</p>
+                  <p className="text-2xl font-bold text-purple-600">{accuracy}%</p>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="space-y-3 pt-4">
+            <Button onClick={onRestart} className="w-full" size="lg">
+              <RotateCcw className="mr-2" size={16} />
+              もう一度学習する
+            </Button>
+
+            <Button onClick={onHome} variant="outline" className="w-full" size="lg">
+              <Home className="mr-2" size={16} />
+              ホームに戻る
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- アラート形式の回答結果表示を専用UIコンポーネントに置き換え
- モーダル形式の回答結果画面とセッション完了画面を追加
- 正解・不正解の視覚的フィードバークと統計表示機能を実装

## Changes
- `AnswerResult`コンポーネント: 回答結果をモーダル表示
- `SessionComplete`コンポーネント: 学習完了画面と正解率統計
- 学習画面のalert削除とUIコンポーネント統合

## Test plan
- [x] 学習機能の動作確認（問題表示・回答入力）
- [x] 回答結果画面の表示確認（正解・不正解）
- [x] セッション完了画面の統計表示確認
- [x] リンター・型チェック通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)