### PR TITLE
feat: 単語管理APIを実装

### DIFF
--- a/docs/deployment/migration-20251108.md
+++ b/docs/deployment/migration-20251108.md
@@ -1,0 +1,184 @@
+# マイグレーション手順: 単語管理API（PR #11）
+
+## 概要
+PR #11 の単語管理API実装に伴い、`words`テーブルにソフトデリート用のカラムを追加します。
+
+## マイグレーション内容
+
+### 追加されるカラム
+- `is_active` (BOOLEAN NOT NULL DEFAULT true) - アクティブ状態フラグ
+- `deleted_at` (TIMESTAMP NULL) - 削除日時
+
+### マイグレーションSQL
+```sql
+ALTER TABLE "words" ADD COLUMN "deleted_at" TIMESTAMP(3);
+ALTER TABLE "words" ADD COLUMN "is_active" BOOLEAN NOT NULL DEFAULT true;
+```
+
+## 既存データへの影響
+
+### 安全性
+✅ **データの破壊的変更なし**
+- 既存のレコードは保持される
+- `is_active`は自動的に`true`に設定される（DEFAULT値）
+- `deleted_at`は`NULL`に設定される（NULL許容カラム）
+
+### 影響範囲
+- 既存の単語データはすべてアクティブ状態（`is_active: true`）として扱われる
+- 出題対象に含まれ続ける（既存の動作と同じ）
+- 学習履歴への影響なし
+
+## デプロイ手順
+
+### 前提条件
+- PR #11 がマージされていること
+- 本番環境の`ADMIN_API_KEY`が設定されていること
+
+### ステップ1: バックアップ確認（推奨）
+Neon PostgreSQL では自動バックアップが有効になっていますが、念のため確認：
+
+1. [Neon Console](https://console.neon.tech/) にログイン
+2. プロジェクトの「Backups」タブで自動バックアップが有効か確認
+3. 必要に応じて手動バックアップを作成
+
+### ステップ2: マイグレーション実行
+
+#### 方法1: Vercel Functions経由（推奨）
+
+Vercelにデプロイされると、自動的にPrismaの設定が適用されますが、マイグレーションは**手動で実行する必要があります**。
+
+1. ローカル環境で本番DBに接続してマイグレーション実行：
+
+```bash
+# 本番環境のDATABASE_URLを設定
+export DATABASE_URL="<本番のNeon PostgreSQL URL>"
+
+# マイグレーション実行（本番用）
+npx prisma migrate deploy
+
+# 実行確認
+npx prisma db pull
+```
+
+#### 方法2: Neon Console経由
+
+1. [Neon Console](https://console.neon.tech/) にログイン
+2. プロジェクトの「SQL Editor」を開く
+3. 以下のSQLを実行：
+
+```sql
+-- マイグレーション実行
+ALTER TABLE "words" ADD COLUMN IF NOT EXISTS "deleted_at" TIMESTAMP(3);
+ALTER TABLE "words" ADD COLUMN IF NOT EXISTS "is_active" BOOLEAN NOT NULL DEFAULT true;
+
+-- 確認
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_name = 'words'
+AND column_name IN ('is_active', 'deleted_at');
+```
+
+### ステップ3: デプロイ確認
+
+1. **アプリケーションの動作確認**
+   ```bash
+   # ヘルスチェック
+   curl https://your-app-domain.vercel.app/api/health
+   ```
+
+2. **マイグレーション確認**
+   ```bash
+   # Prisma Studioで確認（ローカル環境）
+   export DATABASE_URL="<本番URL>"
+   npx prisma studio
+   ```
+
+3. **管理API動作確認**
+   ```bash
+   # 単語検索APIテスト（既存データが取得できることを確認）
+   curl -X GET "https://your-app-domain.vercel.app/api/admin/words?limit=5" \
+     -H "Authorization: Bearer ${ADMIN_API_KEY}"
+   ```
+
+### ステップ4: 動作テスト
+
+以下の操作が正常に動作することを確認：
+
+- ✅ 既存の単語が出題される
+- ✅ 学習機能が正常に動作する
+- ✅ 単語の追加・更新・削除（管理API）が動作する
+- ✅ 削除した単語が出題対象から除外される
+
+## ロールバック手順（緊急時）
+
+万が一、問題が発生した場合のロールバック手順：
+
+### データベースのロールバック
+
+```sql
+-- カラムを削除（データは保持される）
+ALTER TABLE "words" DROP COLUMN IF EXISTS "is_active";
+ALTER TABLE "words" DROP COLUMN IF EXISTS "deleted_at";
+```
+
+### アプリケーションのロールバック
+
+1. Vercel Dashboardで前のデプロイメントに戻す
+2. または、GitHubでPR #11 をリバート
+
+## トラブルシューティング
+
+### マイグレーションエラーが発生した場合
+
+**エラー**: `column "is_active" already exists`
+```bash
+# 解決: IF NOT EXISTS を使用
+ALTER TABLE "words" ADD COLUMN IF NOT EXISTS "is_active" BOOLEAN NOT NULL DEFAULT true;
+```
+
+**エラー**: Permission denied
+```bash
+# 解決: DATABASE_URLが正しいか確認
+echo $DATABASE_URL
+# Neonの接続URLにsslmode=requireが含まれているか確認
+```
+
+### 既存データが取得できない場合
+
+1. データベース接続を確認
+   ```bash
+   npx prisma db pull
+   ```
+
+2. `is_active`フィルタが正しいか確認
+   ```typescript
+   // src/lib/db/queries.ts
+   where: {
+     isActive: true, // この行が追加されていることを確認
+   }
+   ```
+
+## 確認事項チェックリスト
+
+デプロイ前:
+- [ ] PR #11 がマージされている
+- [ ] 本番環境に`ADMIN_API_KEY`が設定されている
+- [ ] Neonの自動バックアップが有効
+
+デプロイ後:
+- [ ] マイグレーションが正常に完了した
+- [ ] `words`テーブルに`is_active`と`deleted_at`カラムが追加されている
+- [ ] 既存の単語データが保持されている
+- [ ] 学習機能が正常に動作する
+- [ ] 管理API（追加・更新・削除）が動作する
+- [ ] 削除した単語が出題対象から除外される
+
+## 参考情報
+
+- **マイグレーションファイル**: `prisma/migrations/20251108085446_add_word_soft_delete_fields/migration.sql`
+- **PR**: https://github.com/ogibayashi/word-practice/pull/11
+- **Prisma ドキュメント**: https://www.prisma.io/docs/guides/migrate/production-troubleshooting
+
+---
+
+**注意**: 本番環境でのマイグレーション実行は慎重に行ってください。必ずバックアップを確認してから実行してください。

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -115,9 +115,42 @@ NEXTAUTH_SECRET=your-production-secret-32-characters-or-more
 LINE_CHANNEL_ID=your-line-channel-id
 LINE_CHANNEL_SECRET=your-line-channel-secret
 
+# 管理API認証（単語管理API用）
+ADMIN_API_KEY=your-admin-api-key-for-word-management
+
 # 本番環境フラグ
 NODE_ENV=production
 ```
+
+#### 環境変数の説明
+
+- **DATABASE_URL**: Neon PostgreSQLの接続URL
+- **NEXTAUTH_URL**: アプリケーションのベースURL（Vercelのドメイン）
+- **NEXTAUTH_SECRET**: NextAuth.jsのセッション暗号化キー（32文字以上のランダム文字列）
+- **LINE_CHANNEL_ID**: LINE LoginのチャネルID
+- **LINE_CHANNEL_SECRET**: LINE Loginのチャネルシークレット
+- **ADMIN_API_KEY**: 単語管理API（POST/PUT/DELETE /api/admin/words）の認証キー
+  - 安全な方法で生成（例: `openssl rand -base64 32`）
+  - 外部に漏洩しないよう厳重に管理
+  - CSVインポート機能など管理者向け操作で使用
+- **NODE_ENV**: 本番環境フラグ
+
+#### セキュリティに関する注意事項
+
+1. **ADMIN_API_KEY の生成**:
+   ```bash
+   # ターミナルで実行
+   openssl rand -base64 32
+   ```
+
+2. **環境変数の管理**:
+   - すべての機密情報はVercelの環境変数として設定
+   - `.env`ファイルは絶対にGitにコミットしない
+   - 定期的にキーをローテーション（特にADMIN_API_KEY）
+
+3. **アクセス制御**:
+   - ADMIN_API_KEYは管理者のみが知るべき情報
+   - APIキーは安全な方法で共有（パスワードマネージャー等）
 
 ### 3.3 ビルド設定
 
@@ -252,6 +285,8 @@ https://your-app-domain.com/api/auth/callback/line
 - [ ] データベース接続が成功する
 - [ ] LINE Loginが動作する
 - [ ] 学習機能が正常動作する
+- [ ] 管理API（単語管理）が認証付きで動作する
+- [ ] ADMIN_API_KEY が正しく設定されている
 - [ ] レスポンス時間が適切である
 - [ ] SSL証明書が有効である
 - [ ] SEOメタタグが設定されている

--- a/prisma/migrations/20251108085446_add_word_soft_delete_fields/migration.sql
+++ b/prisma/migrations/20251108085446_add_word_soft_delete_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "words" ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,11 +29,13 @@ model User {
 
 // 単語マスタ
 model Word {
-  id              String  @id @default(cuid())
-  japaneseMeaning String  @map("japanese_meaning") @db.Text
-  synonyms        String[] // 類義語リスト
-  difficultyLevel Int     @default(1) @map("difficulty_level") // 難易度（将来拡張用）
-  createdAt       DateTime @default(now()) @map("created_at")
+  id              String    @id @default(cuid())
+  japaneseMeaning String    @map("japanese_meaning") @db.Text
+  synonyms        String[]  // 類義語リスト
+  difficultyLevel Int       @default(1) @map("difficulty_level") // 難易度（将来拡張用）
+  isActive        Boolean   @default(true) @map("is_active") // アクティブ状態（ソフトデリート用）
+  createdAt       DateTime  @default(now()) @map("created_at")
+  deletedAt       DateTime? @map("deleted_at") // 削除日時（ソフトデリート用）
 
   // リレーション
   answers         WordAnswer[]

--- a/src/app/api/admin/words/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/words/[id]/__tests__/route.test.ts
@@ -60,7 +60,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -94,7 +94,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -113,7 +113,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -139,7 +139,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(404);
@@ -165,7 +165,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(409);
@@ -191,7 +191,7 @@ describe("PUT /api/admin/words/:id", () => {
       body: JSON.stringify(requestBody),
     });
 
-    const response = await PUT(request, { params: { id: wordId } });
+    const response = await PUT(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -230,7 +230,7 @@ describe("DELETE /api/admin/words/:id", () => {
       },
     });
 
-    const response = await DELETE(request, { params: { id: wordId } });
+    const response = await DELETE(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -251,7 +251,7 @@ describe("DELETE /api/admin/words/:id", () => {
       },
     });
 
-    const response = await DELETE(request, { params: { id: wordId } });
+    const response = await DELETE(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(404);
@@ -271,7 +271,7 @@ describe("DELETE /api/admin/words/:id", () => {
       },
     });
 
-    const response = await DELETE(request, { params: { id: wordId } });
+    const response = await DELETE(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -289,7 +289,7 @@ describe("DELETE /api/admin/words/:id", () => {
       },
     });
 
-    const response = await DELETE(request, { params: { id: wordId } });
+    const response = await DELETE(request, { params: Promise.resolve({ id: wordId }) });
     const data = await response.json();
 
     expect(response.status).toBe(500);

--- a/src/app/api/admin/words/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/words/[id]/__tests__/route.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @jest-environment node
+ */
+
+// モック設定（インポートより前に定義）
+jest.mock("@/lib/services/wordManagementService");
+jest.mock("@/lib/middleware/apiKeyAuth", () => ({
+  validateApiKey: jest.fn(() => null), // デフォルトは認証成功
+}));
+
+import { wordManagementService } from "@/lib/services/wordManagementService";
+import { AdminErrorCode } from "@/types/admin";
+import { NextRequest } from "next/server";
+import { DELETE, PUT } from "../route";
+
+const mockWordManagementService = wordManagementService as jest.Mocked<
+  typeof wordManagementService
+>;
+
+describe("PUT /api/admin/words/:id", () => {
+  const validApiKey = "test-api-key";
+  const wordId = "word-123";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_API_KEY = validApiKey;
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_API_KEY = undefined;
+  });
+
+  it("正常に単語を更新できる", async () => {
+    const mockResponse = {
+      id: wordId,
+      japanese_meaning: "速く走る",
+      answers: [
+        { id: "ans-1", answer: "run", is_primary: true },
+        { id: "ans-2", answer: "sprint", is_primary: false },
+      ],
+      synonyms: ["疾走"],
+      is_active: true,
+      created_at: "2024-01-01T00:00:00.000Z",
+    };
+
+    mockWordManagementService.updateWord.mockResolvedValue(mockResponse);
+
+    const requestBody = {
+      japanese_meaning: "速く走る",
+      answers: ["run", "sprint"],
+      synonyms: ["疾走"],
+    };
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual(mockResponse);
+    expect(mockWordManagementService.updateWord).toHaveBeenCalledWith(wordId, requestBody);
+  });
+
+  it("部分更新: japanese_meaningのみ更新", async () => {
+    const mockResponse = {
+      id: wordId,
+      japanese_meaning: "速く走る",
+      answers: [{ id: "ans-1", answer: "run", is_primary: true }],
+      synonyms: [],
+      is_active: true,
+      created_at: "2024-01-01T00:00:00.000Z",
+    };
+
+    mockWordManagementService.updateWord.mockResolvedValue(mockResponse);
+
+    const requestBody = {
+      japanese_meaning: "速く走る",
+    };
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("バリデーションエラー: フィールドが1つも指定されていない", async () => {
+    const requestBody = {};
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.MISSING_FIELDS);
+  });
+
+  it("エラー: 単語が見つからない", async () => {
+    const error = new Error("指定された単語が見つかりません");
+    error.name = AdminErrorCode.WORD_NOT_FOUND;
+    mockWordManagementService.updateWord.mockRejectedValue(error);
+
+    const requestBody = {
+      japanese_meaning: "走る",
+    };
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.WORD_NOT_FOUND);
+  });
+
+  it("エラー: 重複する日本語の意味", async () => {
+    const error = new Error("この日本語の意味は既に登録されています");
+    error.name = AdminErrorCode.DUPLICATE_WORD;
+    mockWordManagementService.updateWord.mockRejectedValue(error);
+
+    const requestBody = {
+      japanese_meaning: "走る",
+    };
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.DUPLICATE_WORD);
+  });
+
+  it("エラー: 削除済みの単語を更新しようとした", async () => {
+    const error = new Error("削除済みの単語は更新できません");
+    error.name = AdminErrorCode.WORD_ALREADY_DELETED;
+    mockWordManagementService.updateWord.mockRejectedValue(error);
+
+    const requestBody = {
+      japanese_meaning: "走る",
+    };
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.WORD_ALREADY_DELETED);
+  });
+});
+
+describe("DELETE /api/admin/words/:id", () => {
+  const validApiKey = "test-api-key";
+  const wordId = "word-123";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_API_KEY = validApiKey;
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_API_KEY = undefined;
+  });
+
+  it("正常に単語を削除できる（ソフトデリート）", async () => {
+    const mockResponse = {
+      id: wordId,
+      japanese_meaning: "走る",
+      is_active: false as const,
+      deleted_at: "2024-01-01T00:00:00.000Z",
+    };
+
+    mockWordManagementService.deleteWord.mockResolvedValue(mockResponse);
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await DELETE(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual(mockResponse);
+    expect(mockWordManagementService.deleteWord).toHaveBeenCalledWith(wordId);
+  });
+
+  it("エラー: 単語が見つからない", async () => {
+    const error = new Error("指定された単語が見つかりません");
+    error.name = AdminErrorCode.WORD_NOT_FOUND;
+    mockWordManagementService.deleteWord.mockRejectedValue(error);
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await DELETE(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.WORD_NOT_FOUND);
+  });
+
+  it("エラー: 既に削除済みの単語", async () => {
+    const error = new Error("この単語は既に削除されています");
+    error.name = AdminErrorCode.WORD_ALREADY_DELETED;
+    mockWordManagementService.deleteWord.mockRejectedValue(error);
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await DELETE(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.WORD_ALREADY_DELETED);
+  });
+
+  it("データベースエラー", async () => {
+    mockWordManagementService.deleteWord.mockRejectedValue(new Error("Database error"));
+
+    const request = new NextRequest(`http://localhost:3000/api/admin/words/${wordId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await DELETE(request, { params: { id: wordId } });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.DATABASE_ERROR);
+  });
+});

--- a/src/app/api/admin/words/[id]/route.ts
+++ b/src/app/api/admin/words/[id]/route.ts
@@ -1,0 +1,218 @@
+import { validateApiKey } from "@/lib/middleware/apiKeyAuth";
+import { wordManagementService } from "@/lib/services/wordManagementService";
+import {
+  AdminErrorCode,
+  type AdminErrorResponse,
+  type DeleteWordResponse,
+  type UpdateWordRequest,
+  type UpdateWordResponse,
+} from "@/types/admin";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// バリデーションスキーマ
+const UpdateWordSchema = z.object({
+  japanese_meaning: z
+    .string()
+    .min(1, "日本語の意味は1文字以上必要です")
+    .max(500, "日本語の意味は500文字以内です")
+    .optional(),
+  answers: z
+    .array(
+      z.string().min(1, "正解候補は空文字列にできません").max(255, "正解候補は255文字以内です")
+    )
+    .min(1, "正解候補は最低1つ必要です")
+    .max(10, "正解候補は最大10個までです")
+    .optional(),
+  synonyms: z
+    .array(z.string().min(1, "類義語は空文字列にできません").max(100, "類義語は100文字以内です"))
+    .max(20, "類義語は最大20個までです")
+    .optional(),
+});
+
+/**
+ * PUT /api/admin/words/:id - 単語更新API
+ */
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  // APIキー認証
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const { id } = params;
+
+    // リクエストボディを解析
+    const body = await request.json();
+    const validation = UpdateWordSchema.safeParse(body);
+
+    if (!validation.success) {
+      const errorMessages = validation.error.errors
+        .map((err) => `${err.path.join(".")}: ${err.message}`)
+        .join(", ");
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.VALIDATION_ERROR,
+            message: `バリデーションエラー: ${errorMessages}`,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    // 少なくとも1つのフィールドが必要
+    if (
+      !validation.data.japanese_meaning &&
+      !validation.data.answers &&
+      validation.data.synonyms === undefined
+    ) {
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.MISSING_FIELDS,
+            message:
+              "少なくとも1つのフィールド(japanese_meaning, answers, synonyms)を指定してください",
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    // 単語を更新
+    const wordData = await wordManagementService.updateWord(id, {
+      ...(validation.data.japanese_meaning && {
+        japanese_meaning: validation.data.japanese_meaning,
+      }),
+      ...(validation.data.answers && { answers: validation.data.answers }),
+      ...(validation.data.synonyms !== undefined && { synonyms: validation.data.synonyms }),
+    });
+
+    return NextResponse.json<UpdateWordResponse>({
+      success: true,
+      data: wordData,
+    });
+  } catch (error) {
+    console.error("Failed to update word:", error);
+
+    // エラー種別に応じてレスポンスを変更
+    if (error instanceof Error) {
+      if (error.name === AdminErrorCode.WORD_NOT_FOUND) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.WORD_NOT_FOUND,
+              message: error.message,
+            },
+          },
+          { status: 404 }
+        );
+      }
+
+      if (error.name === AdminErrorCode.DUPLICATE_WORD) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.DUPLICATE_WORD,
+              message: error.message,
+              details: {
+                field: "japanese_meaning",
+              },
+            },
+          },
+          { status: 409 }
+        );
+      }
+
+      if (error.name === AdminErrorCode.WORD_ALREADY_DELETED) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.WORD_ALREADY_DELETED,
+              message: error.message,
+            },
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.DATABASE_ERROR,
+          message: "単語の更新に失敗しました",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/words/:id - 単語削除API（ソフトデリート）
+ */
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  // APIキー認証
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const { id } = params;
+
+    // 単語を削除（ソフトデリート）
+    const deletedWord = await wordManagementService.deleteWord(id);
+
+    return NextResponse.json<DeleteWordResponse>({
+      success: true,
+      data: deletedWord,
+    });
+  } catch (error) {
+    console.error("Failed to delete word:", error);
+
+    // エラー種別に応じてレスポンスを変更
+    if (error instanceof Error) {
+      if (error.name === AdminErrorCode.WORD_NOT_FOUND) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.WORD_NOT_FOUND,
+              message: error.message,
+            },
+          },
+          { status: 404 }
+        );
+      }
+
+      if (error.name === AdminErrorCode.WORD_ALREADY_DELETED) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.WORD_ALREADY_DELETED,
+              message: error.message,
+            },
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.DATABASE_ERROR,
+          message: "単語の削除に失敗しました",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/words/[id]/route.ts
+++ b/src/app/api/admin/words/[id]/route.ts
@@ -33,13 +33,13 @@ const UpdateWordSchema = z.object({
 /**
  * PUT /api/admin/words/:id - 単語更新API
  */
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // APIキー認証
   const authError = validateApiKey(request);
   if (authError) return authError;
 
   try {
-    const { id } = params;
+    const { id } = await params;
 
     // リクエストボディを解析
     const body = await request.json();
@@ -157,13 +157,16 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 /**
  * DELETE /api/admin/words/:id - 単語削除API（ソフトデリート）
  */
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   // APIキー認証
   const authError = validateApiKey(request);
   if (authError) return authError;
 
   try {
-    const { id } = params;
+    const { id } = await params;
 
     // 単語を削除（ソフトデリート）
     const deletedWord = await wordManagementService.deleteWord(id);

--- a/src/app/api/admin/words/__tests__/route.test.ts
+++ b/src/app/api/admin/words/__tests__/route.test.ts
@@ -1,0 +1,335 @@
+/**
+ * @jest-environment node
+ */
+
+// モック設定（インポートより前に定義）
+jest.mock("@/lib/services/wordManagementService");
+jest.mock("@/lib/middleware/apiKeyAuth", () => ({
+  validateApiKey: jest.fn(() => null), // デフォルトは認証成功
+}));
+
+import { wordManagementService } from "@/lib/services/wordManagementService";
+import { AdminErrorCode } from "@/types/admin";
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+
+const mockWordManagementService = wordManagementService as jest.Mocked<
+  typeof wordManagementService
+>;
+
+describe("POST /api/admin/words", () => {
+  const validApiKey = "test-api-key";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_API_KEY = validApiKey;
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_API_KEY = undefined;
+  });
+
+  it("正常に単語を作成できる", async () => {
+    const mockResponse = {
+      id: "word-123",
+      japanese_meaning: "走る",
+      answers: [
+        { id: "ans-1", answer: "run", is_primary: true },
+        { id: "ans-2", answer: "jog", is_primary: false },
+      ],
+      synonyms: ["駆ける"],
+      is_active: true,
+      created_at: "2024-01-01T00:00:00.000Z",
+    };
+
+    mockWordManagementService.createWord.mockResolvedValue(mockResponse);
+
+    const requestBody = {
+      japanese_meaning: "走る",
+      answers: ["run", "jog"],
+      synonyms: ["駆ける"],
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual(mockResponse);
+  });
+
+  it("バリデーションエラー: japanese_meaningが空", async () => {
+    const requestBody = {
+      japanese_meaning: "",
+      answers: ["run"],
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+
+  it("バリデーションエラー: answersが空配列", async () => {
+    const requestBody = {
+      japanese_meaning: "走る",
+      answers: [],
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+
+  it("バリデーションエラー: answersが10個を超える", async () => {
+    const requestBody = {
+      japanese_meaning: "走る",
+      answers: Array(11).fill("run"),
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+
+  it("重複エラー: 同じ日本語の意味が既に存在", async () => {
+    const error = new Error("この日本語の意味は既に登録されています");
+    error.name = AdminErrorCode.DUPLICATE_WORD;
+    mockWordManagementService.createWord.mockRejectedValue(error);
+
+    const requestBody = {
+      japanese_meaning: "走る",
+      answers: ["run"],
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.DUPLICATE_WORD);
+  });
+
+  it("データベースエラー", async () => {
+    mockWordManagementService.createWord.mockRejectedValue(new Error("Database error"));
+
+    const requestBody = {
+      japanese_meaning: "走る",
+      answers: ["run"],
+    };
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.DATABASE_ERROR);
+  });
+});
+
+describe("GET /api/admin/words", () => {
+  const validApiKey = "test-api-key";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_API_KEY = validApiKey;
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_API_KEY = undefined;
+  });
+
+  it("正常に単語リストを取得できる", async () => {
+    const mockResponse = {
+      words: [
+        {
+          id: "word-1",
+          japanese_meaning: "走る",
+          answers: ["run", "jog"],
+          synonyms: ["駆ける"],
+          is_active: true,
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      pagination: {
+        total: 1,
+        limit: 20,
+        offset: 0,
+        has_next: false,
+        total_pages: 1,
+      },
+    };
+
+    mockWordManagementService.searchWords.mockResolvedValue(mockResponse);
+
+    const request = new NextRequest("http://localhost:3000/api/admin/words", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual(mockResponse);
+  });
+
+  it("検索クエリを指定して単語を検索できる", async () => {
+    const mockResponse = {
+      words: [
+        {
+          id: "word-1",
+          japanese_meaning: "走る",
+          answers: ["run"],
+          synonyms: [],
+          is_active: true,
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      pagination: {
+        total: 1,
+        limit: 10,
+        offset: 0,
+        has_next: false,
+        total_pages: 1,
+      },
+    };
+
+    mockWordManagementService.searchWords.mockResolvedValue(mockResponse);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/admin/words?search=走&limit=10&offset=0",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${validApiKey}`,
+        },
+      }
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockWordManagementService.searchWords).toHaveBeenCalledWith({
+      search: "走",
+      is_active: "true",
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  it("バリデーションエラー: limitが範囲外", async () => {
+    const request = new NextRequest("http://localhost:3000/api/admin/words?limit=101", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+
+  it("バリデーションエラー: offsetが負の数", async () => {
+    const request = new NextRequest("http://localhost:3000/api/admin/words?offset=-1", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+
+  it("バリデーションエラー: is_activeが不正な値", async () => {
+    const request = new NextRequest("http://localhost:3000/api/admin/words?is_active=invalid", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${validApiKey}`,
+      },
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error.code).toBe(AdminErrorCode.VALIDATION_ERROR);
+  });
+});

--- a/src/app/api/admin/words/route.ts
+++ b/src/app/api/admin/words/route.ts
@@ -1,0 +1,191 @@
+import { validateApiKey } from "@/lib/middleware/apiKeyAuth";
+import { wordManagementService } from "@/lib/services/wordManagementService";
+import {
+  AdminErrorCode,
+  type AdminErrorResponse,
+  type CreateWordRequest,
+  type CreateWordResponse,
+  type SearchWordsResponse,
+} from "@/types/admin";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// バリデーションスキーマ
+const CreateWordSchema = z.object({
+  japanese_meaning: z
+    .string()
+    .min(1, "日本語の意味は必須です")
+    .max(500, "日本語の意味は500文字以内です"),
+  answers: z
+    .array(
+      z.string().min(1, "正解候補は空文字列にできません").max(255, "正解候補は255文字以内です")
+    )
+    .min(1, "正解候補は最低1つ必要です")
+    .max(10, "正解候補は最大10個までです"),
+  synonyms: z
+    .array(z.string().min(1, "類義語は空文字列にできません").max(100, "類義語は100文字以内です"))
+    .max(20, "類義語は最大20個までです")
+    .optional(),
+});
+
+/**
+ * POST /api/admin/words - 単語追加API
+ */
+export async function POST(request: NextRequest) {
+  // APIキー認証
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    // リクエストボディを解析
+    const body = await request.json();
+    const validation = CreateWordSchema.safeParse(body);
+
+    if (!validation.success) {
+      const errorMessages = validation.error.errors
+        .map((err) => `${err.path.join(".")}: ${err.message}`)
+        .join(", ");
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.VALIDATION_ERROR,
+            message: `バリデーションエラー: ${errorMessages}`,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    // 単語を作成
+    const wordData = await wordManagementService.createWord({
+      japanese_meaning: validation.data.japanese_meaning,
+      answers: validation.data.answers,
+      ...(validation.data.synonyms && { synonyms: validation.data.synonyms }),
+    });
+
+    return NextResponse.json<CreateWordResponse>(
+      {
+        success: true,
+        data: wordData,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Failed to create word:", error);
+
+    // エラー種別に応じてレスポンスを変更
+    if (error instanceof Error) {
+      if (error.name === AdminErrorCode.DUPLICATE_WORD) {
+        return NextResponse.json<AdminErrorResponse>(
+          {
+            success: false,
+            error: {
+              code: AdminErrorCode.DUPLICATE_WORD,
+              message: error.message,
+              details: {
+                field: "japanese_meaning",
+              },
+            },
+          },
+          { status: 409 }
+        );
+      }
+    }
+
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.DATABASE_ERROR,
+          message: "単語の作成に失敗しました",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/admin/words - 単語検索API
+ */
+export async function GET(request: NextRequest) {
+  // APIキー認証
+  const authError = validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    // クエリパラメータを取得
+    const searchParams = request.nextUrl.searchParams;
+    const search = searchParams.get("search") || undefined;
+    const isActive = (searchParams.get("is_active") as "true" | "false" | "all" | null) || "true";
+    const limit = Number.parseInt(searchParams.get("limit") || "20", 10);
+    const offset = Number.parseInt(searchParams.get("offset") || "0", 10);
+
+    // バリデーション
+    if (limit < 1 || limit > 100) {
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.VALIDATION_ERROR,
+            message: "limitは1から100の範囲で指定してください",
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    if (offset < 0) {
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.VALIDATION_ERROR,
+            message: "offsetは0以上の値を指定してください",
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!["true", "false", "all"].includes(isActive)) {
+      return NextResponse.json<AdminErrorResponse>(
+        {
+          success: false,
+          error: {
+            code: AdminErrorCode.VALIDATION_ERROR,
+            message: 'is_activeは"true"、"false"、または"all"のいずれかを指定してください',
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    // 単語を検索
+    const result = await wordManagementService.searchWords({
+      ...(search && { search }),
+      is_active: isActive,
+      limit,
+      offset,
+    });
+
+    return NextResponse.json<SearchWordsResponse>({
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    console.error("Failed to search words:", error);
+
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.DATABASE_ERROR,
+          message: "単語の検索に失敗しました",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -36,6 +36,9 @@ export const wordQueries = {
   // ランダムに単語を取得（シンプル版、後で出題アルゴリズムに置き換え）
   async getRandomWords(limit = 10): Promise<QuestionData[]> {
     const words = await prisma.word.findMany({
+      where: {
+        isActive: true, // アクティブな単語のみ取得
+      },
       take: limit,
       include: {
         answers: true,

--- a/src/lib/middleware/apiKeyAuth.ts
+++ b/src/lib/middleware/apiKeyAuth.ts
@@ -1,0 +1,72 @@
+import { AdminErrorCode, type AdminErrorResponse } from "@/types/admin";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * APIキー認証ミドルウェア
+ * Authorization: Bearer <API_KEY> ヘッダーでAPIキーを検証
+ */
+export function validateApiKey(request: NextRequest): NextResponse<AdminErrorResponse> | null {
+  const authHeader = request.headers.get("authorization");
+  const adminApiKey = process.env.ADMIN_API_KEY;
+
+  // 環境変数が設定されていない場合
+  if (!adminApiKey) {
+    console.error("ADMIN_API_KEY environment variable is not set");
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.INVALID_API_KEY,
+          message: "API認証が正しく設定されていません",
+        },
+      },
+      { status: 500 }
+    );
+  }
+
+  // Authorizationヘッダーが存在しない場合
+  if (!authHeader) {
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.INVALID_API_KEY,
+          message: "認証ヘッダーが必要です",
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  // Bearer形式のチェック
+  const [scheme, token] = authHeader.split(" ");
+  if (scheme !== "Bearer" || !token) {
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.INVALID_API_KEY,
+          message: "無効な認証形式です。Bearer形式を使用してください",
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  // APIキーの検証
+  if (token !== adminApiKey) {
+    return NextResponse.json<AdminErrorResponse>(
+      {
+        success: false,
+        error: {
+          code: AdminErrorCode.INVALID_API_KEY,
+          message: "無効なAPIキーです",
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  // 認証成功
+  return null;
+}

--- a/src/lib/services/wordManagementService.ts
+++ b/src/lib/services/wordManagementService.ts
@@ -1,0 +1,277 @@
+import { prisma } from "@/lib/db/client";
+import {
+  AdminErrorCode,
+  type CreateWordRequest,
+  type DeleteWordResponse,
+  type PaginationInfo,
+  type UpdateWordRequest,
+  type WordDetailResponse,
+  type WordListItem,
+} from "@/types/admin";
+import type { Word, WordAnswer } from "@prisma/client";
+
+/**
+ * 単語管理サービス
+ * 単語の作成、更新、削除、検索などの業務ロジックを提供
+ */
+class WordManagementService {
+  /**
+   * 単語を作成
+   * @throws Error バリデーションエラーまたは重複エラー
+   */
+  async createWord(data: CreateWordRequest): Promise<WordDetailResponse> {
+    // 重複チェック
+    const existingWord = await prisma.word.findFirst({
+      where: {
+        japaneseMeaning: data.japanese_meaning,
+        isActive: true,
+      },
+    });
+
+    if (existingWord) {
+      const error = new Error("この日本語の意味は既に登録されています");
+      error.name = AdminErrorCode.DUPLICATE_WORD;
+      throw error;
+    }
+
+    // トランザクション内で単語と正解候補を作成
+    const result = await prisma.$transaction(async (tx) => {
+      // 単語を作成
+      const word = await tx.word.create({
+        data: {
+          japaneseMeaning: data.japanese_meaning,
+          synonyms: data.synonyms || [],
+        },
+      });
+
+      // 正解候補を作成（最初の要素をis_primary: trueに設定）
+      const wordAnswers = await Promise.all(
+        data.answers.map((answer, index) =>
+          tx.wordAnswer.create({
+            data: {
+              wordId: word.id,
+              answer,
+              isPrimary: index === 0,
+            },
+          })
+        )
+      );
+
+      return { word, wordAnswers };
+    });
+
+    return this.formatWordDetailResponse(result.word, result.wordAnswers);
+  }
+
+  /**
+   * 単語を更新
+   * @throws Error バリデーションエラーまたは単語が見つからない
+   */
+  async updateWord(id: string, data: UpdateWordRequest): Promise<WordDetailResponse> {
+    // 単語が存在するか確認
+    const existingWord = await prisma.word.findUnique({
+      where: { id },
+    });
+
+    if (!existingWord) {
+      const error = new Error("指定された単語が見つかりません");
+      error.name = AdminErrorCode.WORD_NOT_FOUND;
+      throw error;
+    }
+
+    // 削除済みの単語は更新不可
+    if (!existingWord.isActive) {
+      const error = new Error("削除済みの単語は更新できません");
+      error.name = AdminErrorCode.WORD_ALREADY_DELETED;
+      throw error;
+    }
+
+    // japanese_meaningを更新する場合、重複チェック（自分以外）
+    if (data.japanese_meaning) {
+      const duplicateWord = await prisma.word.findFirst({
+        where: {
+          japaneseMeaning: data.japanese_meaning,
+          isActive: true,
+          id: { not: id },
+        },
+      });
+
+      if (duplicateWord) {
+        const error = new Error("この日本語の意味は既に登録されています");
+        error.name = AdminErrorCode.DUPLICATE_WORD;
+        throw error;
+      }
+    }
+
+    // トランザクション内で更新
+    const result = await prisma.$transaction(async (tx) => {
+      // 単語を更新
+      const word = await tx.word.update({
+        where: { id },
+        data: {
+          ...(data.japanese_meaning && { japaneseMeaning: data.japanese_meaning }),
+          ...(data.synonyms !== undefined && { synonyms: data.synonyms }),
+        },
+      });
+
+      // answersが提供された場合は全置換
+      let wordAnswers: WordAnswer[];
+      if (data.answers) {
+        // 既存の正解候補を削除
+        await tx.wordAnswer.deleteMany({
+          where: { wordId: id },
+        });
+
+        // 新しい正解候補を作成
+        wordAnswers = await Promise.all(
+          data.answers.map((answer, index) =>
+            tx.wordAnswer.create({
+              data: {
+                wordId: id,
+                answer,
+                isPrimary: index === 0,
+              },
+            })
+          )
+        );
+      } else {
+        // answersが提供されていない場合は既存のものを取得
+        wordAnswers = await tx.wordAnswer.findMany({
+          where: { wordId: id },
+          orderBy: { isPrimary: "desc" },
+        });
+      }
+
+      return { word, wordAnswers };
+    });
+
+    return this.formatWordDetailResponse(result.word, result.wordAnswers);
+  }
+
+  /**
+   * 単語を削除（ソフトデリート）
+   * @throws Error 単語が見つからない
+   */
+  async deleteWord(id: string): Promise<DeleteWordResponse["data"]> {
+    // 単語が存在するか確認
+    const existingWord = await prisma.word.findUnique({
+      where: { id },
+    });
+
+    if (!existingWord) {
+      const error = new Error("指定された単語が見つかりません");
+      error.name = AdminErrorCode.WORD_NOT_FOUND;
+      throw error;
+    }
+
+    // 既に削除済み
+    if (!existingWord.isActive) {
+      const error = new Error("この単語は既に削除されています");
+      error.name = AdminErrorCode.WORD_ALREADY_DELETED;
+      throw error;
+    }
+
+    // ソフトデリート
+    const deletedWord = await prisma.word.update({
+      where: { id },
+      data: {
+        isActive: false,
+        deletedAt: new Date(),
+      },
+    });
+
+    return {
+      id: deletedWord.id,
+      japanese_meaning: deletedWord.japaneseMeaning,
+      is_active: false,
+      deleted_at: deletedWord.deletedAt?.toISOString() || new Date().toISOString(),
+    };
+  }
+
+  /**
+   * 単語を検索
+   */
+  async searchWords(params: {
+    search?: string;
+    is_active?: "true" | "false" | "all";
+    limit?: number;
+    offset?: number;
+  }): Promise<{ words: WordListItem[]; pagination: PaginationInfo }> {
+    const limit = Math.min(params.limit || 20, 100); // 最大100件
+    const offset = params.offset || 0;
+
+    // フィルタ条件を構築
+    const where: {
+      japaneseMeaning?: { contains: string };
+      isActive?: boolean;
+    } = {};
+
+    if (params.search) {
+      where.japaneseMeaning = { contains: params.search };
+    }
+
+    if (params.is_active === "true") {
+      where.isActive = true;
+    } else if (params.is_active === "false") {
+      where.isActive = false;
+    }
+    // "all"の場合はフィルタなし
+
+    // 総件数を取得
+    const total = await prisma.word.count({ where });
+
+    // 単語を取得
+    const words = await prisma.word.findMany({
+      where,
+      include: {
+        answers: {
+          orderBy: { isPrimary: "desc" },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip: offset,
+      take: limit,
+    });
+
+    // レスポンス形式に変換
+    const wordList: WordListItem[] = words.map((word) => ({
+      id: word.id,
+      japanese_meaning: word.japaneseMeaning,
+      answers: word.answers.map((a) => a.answer),
+      synonyms: word.synonyms,
+      is_active: word.isActive,
+      created_at: word.createdAt.toISOString(),
+    }));
+
+    const pagination: PaginationInfo = {
+      total,
+      limit,
+      offset,
+      has_next: offset + limit < total,
+      total_pages: Math.ceil(total / limit),
+    };
+
+    return { words: wordList, pagination };
+  }
+
+  /**
+   * WordとWordAnswerをWordDetailResponseに変換
+   */
+  private formatWordDetailResponse(word: Word, wordAnswers: WordAnswer[]): WordDetailResponse {
+    return {
+      id: word.id,
+      japanese_meaning: word.japaneseMeaning,
+      answers: wordAnswers.map((a) => ({
+        id: a.id,
+        answer: a.answer,
+        is_primary: a.isPrimary,
+      })),
+      synonyms: word.synonyms,
+      is_active: word.isActive,
+      created_at: word.createdAt.toISOString(),
+      ...(word.deletedAt && { deleted_at: word.deletedAt.toISOString() }),
+    };
+  }
+}
+
+export const wordManagementService = new WordManagementService();

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,108 @@
+// 管理API用の型定義
+
+// エラーレスポンス
+export interface AdminErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+}
+
+// 単語追加リクエスト
+export interface CreateWordRequest {
+  japanese_meaning: string;
+  answers: string[];
+  synonyms?: string[];
+}
+
+// 単語更新リクエスト
+export interface UpdateWordRequest {
+  japanese_meaning?: string;
+  answers?: string[];
+  synonyms?: string[];
+}
+
+// 正解候補レスポンス
+export interface WordAnswerResponse {
+  id: string;
+  answer: string;
+  is_primary: boolean;
+}
+
+// 単語レスポンス（詳細）
+export interface WordDetailResponse {
+  id: string;
+  japanese_meaning: string;
+  answers: WordAnswerResponse[];
+  synonyms: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at?: string;
+  deleted_at?: string;
+}
+
+// 単語追加レスポンス
+export interface CreateWordResponse {
+  success: true;
+  data: WordDetailResponse;
+}
+
+// 単語更新レスポンス
+export interface UpdateWordResponse {
+  success: true;
+  data: WordDetailResponse;
+}
+
+// 単語削除レスポンス
+export interface DeleteWordResponse {
+  success: true;
+  data: {
+    id: string;
+    japanese_meaning: string;
+    is_active: false;
+    deleted_at: string;
+  };
+}
+
+// ページネーション情報
+export interface PaginationInfo {
+  total: number;
+  limit: number;
+  offset: number;
+  has_next: boolean;
+  total_pages: number;
+}
+
+// 単語リスト項目
+export interface WordListItem {
+  id: string;
+  japanese_meaning: string;
+  answers: string[];
+  synonyms: string[];
+  is_active: boolean;
+  created_at: string;
+}
+
+// 単語検索レスポンス
+export interface SearchWordsResponse {
+  success: true;
+  data: {
+    words: WordListItem[];
+    pagination: PaginationInfo;
+  };
+}
+
+// エラーコード
+export const AdminErrorCode = {
+  INVALID_API_KEY: "INVALID_API_KEY",
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  DUPLICATE_WORD: "DUPLICATE_WORD",
+  WORD_NOT_FOUND: "WORD_NOT_FOUND",
+  WORD_ALREADY_DELETED: "WORD_ALREADY_DELETED",
+  DATABASE_ERROR: "DATABASE_ERROR",
+  MISSING_FIELDS: "MISSING_FIELDS",
+} as const;
+
+export type AdminErrorCodeType = (typeof AdminErrorCode)[keyof typeof AdminErrorCode];


### PR DESCRIPTION
## 概要
issue #10 の単語管理API実装を完了しました。

docs/api.md の設計に基づいて、管理者向けの単語追加・更新・削除・検索機能をREST API形式で実装しました。

## 実装内容

### データベース変更
- ✅ Prisma schemaに`isActive`（Boolean, default: true）と`deletedAt`（DateTime?）フィールドを追加
- ✅ マイグレーションを作成・適用済み

### 認証機能
- ✅ APIキー認証ミドルウェアを実装（`Authorization: Bearer <API_KEY>`）
- ✅ 環境変数`ADMIN_API_KEY`でAPIキーを管理

### エンドポイント実装

#### 1. POST /api/admin/words - 単語追加API
- バリデーション（japanese_meaning: 必須・重複チェック、answers: 必須配列1-10個、synonyms: オプション配列0-20個）
- トランザクション処理（単語作成 + 正解候補作成）
- 正解候補の最初の要素を`is_primary: true`に設定

#### 2. PUT /api/admin/words/:id - 単語更新API
- 少なくとも1つのフィールドが必要
- 正解候補は全置換方式
- 削除済み単語の更新を拒否

#### 3. DELETE /api/admin/words/:id - 単語削除API（ソフトデリート）
- `isActive`をfalseに設定
- `deletedAt`にタイムスタンプを記録
- 学習履歴を保護

#### 4. GET /api/admin/words - 単語検索API
- クエリパラメータ: search, is_active, limit, offset
- ページネーション対応

### サービス層
- `wordManagementService`で業務ロジックを実装
- Prismaの`$transaction`を使用して整合性を保証
- 統一されたエラーハンドリング

### テスト
- ✅ 各エンドポイントに対する包括的なunit testを実装
- ✅ 正常系・異常系の両方をカバー
- ✅ 全21テストが成功

### その他の変更
- 単語取得クエリに`isActive: true`フィルタを追加
- アクティブな単語のみを出題対象とする

## ファイル構成
```
src/
├── app/api/admin/
│   └── words/
│       ├── route.ts                    # GET, POST
│       ├── [id]/
│       │   └── route.ts                # PUT, DELETE
│       └── __tests__/
│           ├── route.test.ts           # GET, POST tests (10 tests)
│           └── [id]/route.test.ts      # PUT, DELETE tests (11 tests)
├── lib/
│   ├── middleware/
│   │   └── apiKeyAuth.ts               # APIキー認証ミドルウェア
│   └── services/
│       └── wordManagementService.ts    # 単語管理ロジック
└── types/
    └── admin.ts                        # 管理API用の型定義
```

## テスト結果
```
Test Suites: 2 passed, 2 total
Tests:       21 passed, 21 total
```

## チェックリスト
- ✅ 型チェック（`pnpm type-check`）成功
- ✅ リンター（`pnpm lint`）成功
- ✅ ユニットテスト（21テスト）成功
- ✅ データベースマイグレーション作成済み
- ✅ APIキー認証実装済み
- ✅ エラーハンドリング実装済み
- ✅ ドキュメント（docs/api.md）と一致

## 使用例

### 単語追加
```bash
curl -X POST http://localhost:3000/api/admin/words \
  -H "Authorization: Bearer your-api-key" \
  -H "Content-Type: application/json" \
  -d '{"japanese_meaning": "走る", "answers": ["run", "jog"], "synonyms": ["駆ける"]}'
```

### 単語検索
```bash
curl -X GET "http://localhost:3000/api/admin/words?search=走&limit=10&offset=0" \
  -H "Authorization: Bearer your-api-key"
```

Close #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

---

## ⚠️ デプロイ時の重要な注意事項

### データベースマイグレーションが必要です

このPRには`words`テーブルへのスキーマ変更が含まれています。

#### マイグレーション内容
- `is_active` (BOOLEAN) カラムの追加
- `deleted_at` (TIMESTAMP) カラムの追加

#### デプロイ手順
詳細な手順は **[docs/deployment/migration-20251108.md](https://github.com/ogibayashi/word-practice/blob/feature/word-management-api-implementation/docs/deployment/migration-20251108.md)** を参照してください。

#### 必須作業
1. **マイグレーション実行** (本番環境で):
   ```bash
   export DATABASE_URL="<本番のNeon PostgreSQL URL>"
   npx prisma migrate deploy
   ```

2. **環境変数設定** (Vercel):
   ```bash
   ADMIN_API_KEY=<openssl rand -base64 32で生成>
   ```

3. **動作確認**:
   - 既存の単語が正常に取得できること
   - 学習機能が動作すること
   - 管理APIが認証付きで動作すること

#### データへの影響
✅ **既存データは安全に保持されます**
- 既存の単語は自動的に`is_active: true`に設定
- 学習履歴への影響なし
- データの破壊的変更なし
