### PR TITLE
build(deps-dev): upgrade @biomejs/biome 1.9.4 → 2.4.16

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,7 +7,15 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["node_modules/**", ".next/**", "dist/**", "build/**", "*.config.js", ".claude/**"]
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/.next",
+      "!**/dist",
+      "!**/build",
+      "!**/*.config.js",
+      "!**/.claude"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -23,7 +31,8 @@
         "noNonNullAssertion": "off"
       },
       "suspicious": {
-        "noExplicitAny": "warn"
+        "noExplicitAny": "warn",
+        "noUnknownAtRules": "off"
       },
       "complexity": {
         "noForEach": "off"
@@ -43,6 +52,11 @@
   "json": {
     "formatter": {
       "enabled": true
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.4.16",
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { type PlaywrightTestConfig, defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/test";
 
 const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^2.4.16
+        version: 2.4.16
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -306,55 +306,55 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2851,39 +2851,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.16':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
   '@csstools/color-helpers@5.1.0': {}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/hooks/useAuth";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 export default function LoginPage() {
   const [displayName, setDisplayName] = useState("");

--- a/src/app/api/admin/words/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/words/[id]/__tests__/route.test.ts
@@ -8,9 +8,9 @@ jest.mock("@/lib/middleware/apiKeyAuth", () => ({
   validateApiKey: jest.fn(() => null), // デフォルトは認証成功
 }));
 
+import { NextRequest } from "next/server";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import { AdminErrorCode } from "@/types/admin";
-import { NextRequest } from "next/server";
 import { DELETE, PUT } from "../route";
 
 const mockWordManagementService = wordManagementService as jest.Mocked<

--- a/src/app/api/admin/words/[id]/route.ts
+++ b/src/app/api/admin/words/[id]/route.ts
@@ -1,14 +1,13 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateApiKey } from "@/lib/middleware/apiKeyAuth";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import {
   AdminErrorCode,
   type AdminErrorResponse,
   type DeleteWordResponse,
-  type UpdateWordRequest,
   type UpdateWordResponse,
 } from "@/types/admin";
-import { type NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 // バリデーションスキーマ
 const UpdateWordSchema = z.object({

--- a/src/app/api/admin/words/__tests__/route.test.ts
+++ b/src/app/api/admin/words/__tests__/route.test.ts
@@ -8,9 +8,9 @@ jest.mock("@/lib/middleware/apiKeyAuth", () => ({
   validateApiKey: jest.fn(() => null), // デフォルトは認証成功
 }));
 
+import { NextRequest } from "next/server";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import { AdminErrorCode } from "@/types/admin";
-import { NextRequest } from "next/server";
 import { GET, POST } from "../route";
 
 const mockWordManagementService = wordManagementService as jest.Mocked<

--- a/src/app/api/admin/words/batch/__tests__/route.test.ts
+++ b/src/app/api/admin/words/batch/__tests__/route.test.ts
@@ -8,9 +8,9 @@ jest.mock("@/lib/middleware/apiKeyAuth", () => ({
   validateApiKey: jest.fn(() => null), // デフォルトは認証成功
 }));
 
+import { NextRequest } from "next/server";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import { AdminErrorCode } from "@/types/admin";
-import { NextRequest } from "next/server";
 import { POST } from "../route";
 
 const mockWordManagementService = wordManagementService as jest.Mocked<

--- a/src/app/api/admin/words/batch/route.ts
+++ b/src/app/api/admin/words/batch/route.ts
@@ -1,13 +1,12 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateApiKey } from "@/lib/middleware/apiKeyAuth";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import {
   AdminErrorCode,
   type AdminErrorResponse,
-  type BatchCreateWordRequest,
   type BatchCreateWordResponse,
 } from "@/types/admin";
-import { type NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 // バリデーションスキーマ（既存のCreateWordSchemaと同じ）
 const CreateWordSchema = z.object({

--- a/src/app/api/admin/words/route.ts
+++ b/src/app/api/admin/words/route.ts
@@ -1,14 +1,13 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateApiKey } from "@/lib/middleware/apiKeyAuth";
 import { wordManagementService } from "@/lib/services/wordManagementService";
 import {
   AdminErrorCode,
   type AdminErrorResponse,
-  type CreateWordRequest,
   type CreateWordResponse,
   type SearchWordsResponse,
 } from "@/types/admin";
-import { type NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 // バリデーションスキーマ
 const CreateWordSchema = z.object({

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
-import { userQueries } from "@/lib/db/queries";
-import type { ApiResponse } from "@/types/database";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { userQueries } from "@/lib/db/queries";
+import type { ApiResponse } from "@/types/database";
 
 // リクエストボディのバリデーション
 const LoginSchema = z.object({

--- a/src/app/api/learning-history/route.ts
+++ b/src/app/api/learning-history/route.ts
@@ -1,6 +1,6 @@
-import { prisma as db } from "@/lib/db/client";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { prisma as db } from "@/lib/db/client";
 
 // 学習履歴保存用のバリデーションスキーマ
 const CreateLearningHistorySchema = z.object({

--- a/src/app/api/sessions/[id]/answer/route.ts
+++ b/src/app/api/sessions/[id]/answer/route.ts
@@ -1,8 +1,8 @@
-import { prisma as db } from "@/lib/db/client";
-import { submitMockAnswer } from "@/lib/db/mockSession";
-import type { ApiResponse, SubmitAnswerRequest, SubmitAnswerResponse } from "@/types/database";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { prisma as db } from "@/lib/db/client";
+import { submitMockAnswer } from "@/lib/db/mockSession";
+import type { ApiResponse, SubmitAnswerResponse } from "@/types/database";
 
 // リクエストボディのバリデーション
 const SubmitAnswerSchema = z.object({

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,8 +1,8 @@
+import { type NextRequest, NextResponse } from "next/server";
 import { getMockSession } from "@/lib/db/mockSession";
 import type { ApiResponse } from "@/types/database";
-import { type NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
 

--- a/src/app/api/sessions/[id]/stats/route.ts
+++ b/src/app/api/sessions/[id]/stats/route.ts
@@ -1,8 +1,8 @@
+import { type NextRequest, NextResponse } from "next/server";
 import { getMockSessionStats } from "@/lib/db/mockSession";
 import type { ApiResponse } from "@/types/database";
-import { type NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
 

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,7 +1,7 @@
-import { sessionService } from "@/lib/services/sessionService";
-import type { ApiResponse, CreateSessionRequest, CreateSessionResponse } from "@/types/database";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { sessionService } from "@/lib/services/sessionService";
+import type { ApiResponse, CreateSessionResponse } from "@/types/database";
 
 // 定数定義
 const MIN_QUESTIONS = 1;

--- a/src/app/api/users/[userId]/stats/route.ts
+++ b/src/app/api/users/[userId]/stats/route.ts
@@ -1,6 +1,6 @@
-import { prisma as db } from "@/lib/db/client";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { prisma as db } from "@/lib/db/client";
 
 // パラメータの型定義
 interface RouteParams {
@@ -13,7 +13,7 @@ const UserIdSchema = z.string().min(1, "ユーザーIDが必要です");
  * GET /api/users/[userId]/stats
  * ユーザーの学習統計情報を取得する
  */
-export async function GET(request: NextRequest, context: { params: Promise<RouteParams> }) {
+export async function GET(_request: NextRequest, context: { params: Promise<RouteParams> }) {
   try {
     const params = await context.params;
     const userId = UserIdSchema.parse(params.userId);

--- a/src/app/api/words/[id]/check/route.ts
+++ b/src/app/api/words/[id]/check/route.ts
@@ -1,7 +1,7 @@
-import { checkAnswerWithFallback } from "@/lib/db/fallback";
-import type { ApiResponse } from "@/types/database";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { checkAnswerWithFallback } from "@/lib/db/fallback";
+import type { ApiResponse } from "@/types/database";
 
 // リクエストボディのバリデーション
 const CheckAnswerSchema = z.object({

--- a/src/app/api/words/[id]/route.ts
+++ b/src/app/api/words/[id]/route.ts
@@ -1,8 +1,8 @@
+import { type NextRequest, NextResponse } from "next/server";
 import { getWordByIdWithFallback } from "@/lib/db/fallback";
 import type { ApiResponse, QuestionData } from "@/types/database";
-import { type NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
 

--- a/src/app/api/words/random/route.ts
+++ b/src/app/api/words/random/route.ts
@@ -1,6 +1,6 @@
+import { type NextRequest, NextResponse } from "next/server";
 import { getWordsWithFallback } from "@/lib/db/fallback";
 import type { ApiResponse, QuestionData } from "@/types/database";
-import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { AnswerResult } from "@/components/features/AnswerResult";
 import { ErrorDialog } from "@/components/features/ErrorDialog";
 import { SessionComplete } from "@/components/features/SessionComplete";
@@ -14,9 +16,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { getUserFromStorage } from "@/lib/auth/localStorage";
-import type { CreateSessionResponse } from "@/types/database";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 // 学習ページで使用する型定義
 interface Word {
@@ -66,6 +65,7 @@ export default function LearnPage() {
   const [correctCount, setCorrectCount] = useState(0);
   const router = useRouter();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initializeSession should only run on mount
   useEffect(() => {
     const user = getUserFromStorage();
     if (!user) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
-import Link from "next/link";
 
 export default function HomePage() {
   const { isLoggedIn, user } = useAuth();

--- a/src/components/features/AnswerResult.tsx
+++ b/src/components/features/AnswerResult.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { CheckCircle, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CheckCircle, XCircle } from "lucide-react";
 
 interface AnswerResultProps {
   isCorrect: boolean;

--- a/src/components/features/ErrorDialog.tsx
+++ b/src/components/features/ErrorDialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
 
 interface ErrorDialogProps {
   title: string;

--- a/src/components/features/SessionComplete.tsx
+++ b/src/components/features/SessionComplete.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Home, RotateCcw, Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Home, RotateCcw, Trophy } from "lucide-react";
 
 interface SessionCompleteProps {
   totalQuestions: number;

--- a/src/components/features/auth/AuthGuard.tsx
+++ b/src/components/features/auth/AuthGuard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useAuth } from "@/hooks/useAuth";
 import { useRouter } from "next/navigation";
 import { type PropsWithChildren, useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
 
 interface AuthGuardProps {
   redirectTo?: string;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
-import Link from "next/link";
 
 export function Header() {
   const { user, isLoggedIn, logout } = useAuth();

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -52,4 +52,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,14 +1,12 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { LocalUser } from "@/lib/auth/localStorage";
 import {
   clearUserFromStorage,
   getUserFromStorage,
-  isUserLoggedIn,
-  saveUserToStorage,
   validateDisplayName,
 } from "@/lib/auth/localStorage";
-import { useEffect, useState } from "react";
 
 export interface UseAuthReturn {
   user: LocalUser | null;

--- a/src/lib/db/__tests__/mockData.test.ts
+++ b/src/lib/db/__tests__/mockData.test.ts
@@ -99,7 +99,7 @@ describe("mockData utilities", () => {
 
   describe("mockWords data integrity", () => {
     it("全ての単語が必要なプロパティを持つ", () => {
-      mockWords.forEach((word, index) => {
+      mockWords.forEach((word, _index) => {
         expect(word.id).toBeDefined();
         expect(word.japaneseMeaning).toBeDefined();
         expect(word.answers).toBeDefined();

--- a/src/lib/db/fallback.ts
+++ b/src/lib/db/fallback.ts
@@ -2,7 +2,7 @@
 
 import type { QuestionData } from "@/types/database";
 import { prisma } from "./client";
-import { checkMockAnswer, getMockWordById, getRandomMockWords } from "./mockData";
+import { getMockWordById, getRandomMockWords } from "./mockData";
 import { wordQueries } from "./queries";
 
 // データベース接続をチェック

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -1,5 +1,5 @@
-import type { QuestionData, WordStats, WordWithAnswers } from "@/types/database";
 import { Prisma } from "@prisma/client";
+import type { QuestionData, WordStats, WordWithAnswers } from "@/types/database";
 import { prisma } from "./client";
 
 // ユーザー関連のクエリ

--- a/src/lib/middleware/apiKeyAuth.ts
+++ b/src/lib/middleware/apiKeyAuth.ts
@@ -1,5 +1,5 @@
-import { AdminErrorCode, type AdminErrorResponse } from "@/types/admin";
 import { type NextRequest, NextResponse } from "next/server";
+import { AdminErrorCode, type AdminErrorResponse } from "@/types/admin";
 
 /**
  * APIキー認証ミドルウェア

--- a/src/lib/services/wordManagementService.ts
+++ b/src/lib/services/wordManagementService.ts
@@ -1,3 +1,4 @@
+import type { Word, WordAnswer } from "@prisma/client";
 import { prisma } from "@/lib/db/client";
 import {
   AdminErrorCode,
@@ -9,7 +10,6 @@ import {
   type WordDetailResponse,
   type WordListItem,
 } from "@/types/admin";
-import type { Word, WordAnswer } from "@prisma/client";
 
 /**
  * 単語管理サービス
@@ -334,7 +334,7 @@ class WordManagementService {
         failed: 0,
         errors: [],
       };
-    } catch (error) {
+    } catch (_error) {
       // トランザクション全体が失敗
       return {
         created: 0,

--- a/src/lib/utils/csvParser.ts
+++ b/src/lib/utils/csvParser.ts
@@ -1,5 +1,5 @@
-import type { CreateWordRequest } from "@/types/admin";
 import Papa from "papaparse";
+import type { CreateWordRequest } from "@/types/admin";
 
 /**
  * CSV行の型定義

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,7 +1,7 @@
 import type { LearningHistory, Session, User, Word, WordAnswer } from "@prisma/client";
 
 // 基本的な型定義をエクスポート
-export type { User, Word, WordAnswer, Session, LearningHistory };
+export type { LearningHistory, Session, User, Word, WordAnswer };
 
 // 拡張型定義
 export type WordWithAnswers = Word & {


### PR DESCRIPTION
## Summary

- `@biomejs/biome` を `1.9.4` → `2.4.16` にメジャーアップグレード
- `pnpm biome migrate --write` で `biome.json` を v2 スキーマに変換（`files.ignore` → `files.includes`）
- v2 から強化された組み込みルールにより発生する指摘を解消:
  - `assist/source/organizeImports` で全ファイルの import を整列
  - 未使用 import / function parameter / variable を `--unsafe` 自動修正で削除/リネーム
  - `lint/correctness/useExhaustiveDependencies` (mount-only effect) は `biome-ignore` コメントで明示
- Tailwind 用に CSS パーサで `tailwindDirectives: true` を有効化（`@apply` の parse エラー解消）
- `lint/suspicious/noUnknownAtRules` を off に設定（Tailwind プロジェクトのため `@tailwind` 等は許容したい）

## Test plan

- [x] `pnpm lint` → エラー/警告 0
- [x] `pnpm type-check` → エラー 0
- [x] `pnpm test` → 9 suites / 93 tests 全 pass
- [x] `pnpm build` → success
- [ ] CI green

## Notes

Dependabot PR #18 と同じパッケージ更新を含むため、本 PR がマージされ次第 PR #18 はクローズ予定です。

Close #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)